### PR TITLE
Improved readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,22 @@
-# Bar Community Repo policy
+# Repo policy
+- All PR's must place the widget include the widget and a readme.md file, they should be placed in `widgets/{widget_name}`. Each folder within `widgets` should only have one widget.
+- The readme.md must include the purpose and customization options regarding the widget
+- You may not submit a PR to a widget you do not control or have permission to modify
+- This is not your personal development page; please create your own space for developing your widget
 
+# Widget policy
+- Widgets should not violate the Code of Conduct and must be in line with what the Game Design Team has deemed allowable.
+    - The widget doesn't give an unfair/unreasonable advantage.
+    - The widget's code is clean and easy to read.
+    - The widget does not exploit game mechanics. 
+    - The widget does not create performance issues for all players in a match.
 
-
-1. ALL PR's must include the widget and a Markdown file.
-
-2. The markdown file must include the purpose and customization options regarding the widget
-
-3. You may not submit a PR to a widget you do not control or have permission to write on
-
-4. The widget does not violate the Code of Conduct and is in line with what the Game Design council has deemed allowable.
-
-    4a. The widget doesn't give an unfair/unreasonable advantage.
- 
-    4b. The widget's code is clean and easy to read.
- 
-    4c. The widget does not exploit game mechanics.
- 
-    4d. The widget does not create performance issues for all players in a match.
-
-5. You may not use this page as your personal development page. Please create your own space for developing your widget
-
-6. The widget cannot be a duplicate of another already approved/rejected widget
-
-7. Do not steal other peoples widgets and upload them as your own
-
-8. Do not violate the license of other widgets if the owner gave you permission to make a PR regarding the owners widget
-
-9. ALL submitted widgets must have GPL_V2 license.
-
-10. Rejected widgets may be resubmitted if the rejection was made with the condition all violations are resolved
-
-11. Widgets that have been rejected with prejudice may not be resubmitted 
-
-12. It is not on the Maintainer of this repo to ensure that your widget works with the current game.
-
-13. A widget can be considered abandoned if there has been no work on the widget in the past X time and the widget no longer works with the current game
-
-14. Anyone can make a PR to an abandoned widget if the PR makes the widget work again. The person who submitted the fix to the widget now becomes the owner of the widget
+- The widget cannot be a duplicate of another already approved/rejected widget; do not steal other peoples widgets and upload them as your own
+- Do not violate the license of other widgets if the owner gave you permission to make a PR regarding the owners widget
+- All submitted widgets must have GPL_V2 license.
+- Rejected widgets may be resubmitted if the rejection was made with the condition all violations are resolved
+- Widgets that have been rejected with prejudice may not be resubmitted 
+- It is not on the maintainers (The BAR team) of this repo to ensure that your widget works with the current game.
+- A widget can be considered abandoned if there has been no work on the widget in the past X time and the widget no longer works with the current game
+- Anyone can make a PR to an abandoned widget if the PR makes the widget work again. The person who submitted the fix to the widget now becomes the owner of the widget
 

--- a/widgets/placeholderfile
+++ b/widgets/placeholderfile
@@ -1,0 +1,1 @@
+This is an file to make the folder; it will be removed later.


### PR DESCRIPTION
@drivver44

- This breaks the rules into repo and widget specific stuff and uses the standard markdown list definition syntax rather than manually numbering items
- It combines a couple of items which overlapped
- It removes a few instances of ALL and replaces them with appropriately cased text